### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # preact-cli-lodash
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/TcwA1EShekGpPzRyQvGn9ysQ/SaraVieira/preact-cli-lodash'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/TcwA1EShekGpPzRyQvGn9ysQ/SaraVieira/preact-cli-lodash.svg' />
-</a>
+
 
 Minify build when using lodash and preact-cli
 


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8